### PR TITLE
[M01] Fees cannot be collected

### DIFF
--- a/packages/primitive-contracts/contracts/option/interfaces/IOption.sol
+++ b/packages/primitive-contracts/contracts/option/interfaces/IOption.sol
@@ -1,11 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-
-
-
-
-
-
 pragma solidity ^0.6.2;
 
 interface IOption {
@@ -74,7 +68,4 @@ interface IOption {
         );
 
     function initRedeemToken(address _redeemToken) external;
-
-    // solhint-disable-next-line
-    function EXERCISE_FEE() external view returns (uint256);
 }

--- a/packages/primitive-contracts/contracts/option/primitives/Option.sol
+++ b/packages/primitive-contracts/contracts/option/primitives/Option.sol
@@ -1,11 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-
-
-
-
-
-
 pragma solidity ^0.6.2;
 
 /**
@@ -32,7 +26,6 @@ contract Option is IOption, ERC20, ReentrancyGuard, Pausable {
     Primitives.Option public parameters;
 
     // solhint-disable-next-line const-name-snakecase
-    uint256 public constant override EXERCISE_FEE = 1000;
     uint256 public override underlyingCache;
     uint256 public override strikeCache;
     address public override redeemToken;
@@ -221,18 +214,13 @@ contract Option is IOption, ERC20, ReentrancyGuard, Pausable {
         // Either underlyingTokens or strikeTokens must be sent into the contract.
         require(inStrikes > 0 || inUnderlyings > 0, "ERR_ZERO");
 
-        // Add the fee to the total required payment.
-        uint256 feeToPay = outUnderlyings.div(EXERCISE_FEE);
-
         // Calculate the remaining amount of underlyingToken that needs to be paid for.
         uint256 remainder = inUnderlyings > outUnderlyings
             ? 0
             : outUnderlyings.sub(inUnderlyings);
 
         // Calculate the expected payment of strikeTokens.
-        uint256 payment = remainder.add(feeToPay).mul(parameters.quote).div(
-            parameters.base
-        );
+        uint256 payment = remainder.mul(parameters.quote).div(parameters.base);
 
         // Assumes the cached optionToken balance is 0, which is what it should be.
         inOptions = balanceOf(address(this));


### PR DESCRIPTION
## Fixes M01
- The exercise function has a fee calculated and taken, denominated in strike tokens. These fees are not pointed to any EOA or contract, so they have been removed.

## Notes
- Future versions of the protocol can implement fees in the exercise function and point the proceeds to any EOA or contract.