### PR TITLE
[M04] Mismatches between contracts and interfaces

### DIFF
--- a/packages/primitive-contracts/contracts/option/interfaces/IOption.sol
+++ b/packages/primitive-contracts/contracts/option/interfaces/IOption.sol
@@ -59,8 +59,8 @@ interface IOption {
         external
         view
         returns (
-            address _strikeToken,
             address _underlyingToken,
+            address _strikeToken,
             address _redeemToken,
             uint256 _base,
             uint256 _quote,
@@ -68,4 +68,8 @@ interface IOption {
         );
 
     function initRedeemToken(address _redeemToken) external;
+
+    function update() external;
+
+    function take() external;
 }

--- a/packages/primitive-contracts/contracts/option/interfaces/IRedeem.sol
+++ b/packages/primitive-contracts/contracts/option/interfaces/IRedeem.sol
@@ -1,15 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-
-
-
-
-
-
-
-
-
-
 pragma solidity ^0.6.2;
 
 interface IRedeem {
@@ -22,4 +12,10 @@ interface IRedeem {
     function mint(address user, uint256 amount) external;
 
     function burn(address user, uint256 amount) external;
+
+    function initialize(
+        address _factory,
+        address _optionToken,
+        address _redeemableToken
+    ) external;
 }

--- a/packages/primitive-contracts/contracts/option/interfaces/ITrader.sol
+++ b/packages/primitive-contracts/contracts/option/interfaces/ITrader.sol
@@ -1,15 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-
-
-
-
-
-
-
-
-
-
 pragma solidity ^0.6.2;
 
 import { IOption } from "./IOption.sol";
@@ -19,13 +9,13 @@ interface ITrader {
         IOption optionToken,
         uint256 mintQuantity,
         address receiver
-    ) external returns (uint256 inTokenU, uint256 outTokenR);
+    ) external returns (uint256 outputOptions, uint256 outputRedeems);
 
     function safeExercise(
         IOption optionToken,
         uint256 exerciseQuantity,
         address receiver
-    ) external returns (uint256 inTokenS, uint256 inOptions);
+    ) external returns (uint256 inStrikes, uint256 inOptions);
 
     function safeRedeem(
         IOption optionToken,


### PR DESCRIPTION
## Fixes
- Adds `initialize()` function to IRedeem.sol interface.
- Adds `update()` and `take()` to IOption.sol interface.
- Reorders first two return variable addresses in `IOption.getParameters()` to match `Option.getParameters()`.
- Fixes mismatch between return variable names in ITrader.sol interface and Trader.sol.

## Notes
- `kill()` is missing an interface implementation, but this function was removed in one of the previous PRs.