### PR TITLE
Removes whenNotPaused modifier

### DIFF
--- a/packages/primitive-contracts/contracts/option/applications/Registry.sol
+++ b/packages/primitive-contracts/contracts/option/applications/Registry.sol
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-
-
 pragma solidity ^0.6.2;
 
 /**
@@ -87,10 +85,6 @@ contract Registry is IRegistry, Ownable, Pausable, ReentrancyGuard {
 
         IOptionFactory(optionFactory).initialize(option, redeem);
         emit Deploy(msg.sender, option, id);
-    }
-
-    function kill(address option) external override onlyOwner {
-        IOptionFactory(optionFactory).kill(option);
     }
 
     function optionsLength() public override view returns (uint256 len) {

--- a/packages/primitive-contracts/contracts/option/primitives/Option.sol
+++ b/packages/primitive-contracts/contracts/option/primitives/Option.sol
@@ -134,7 +134,6 @@ contract Option is IOption, ERC20, ReentrancyGuard {
         override
         nonReentrant
         notExpired
-        whenNotPaused
         returns (uint256 inUnderlyings, uint256 outRedeems)
     {
         // Save on gas because this variable is used twice.
@@ -173,7 +172,6 @@ contract Option is IOption, ERC20, ReentrancyGuard {
         override
         nonReentrant
         notExpired
-        whenNotPaused
         returns (uint256 inStrikes, uint256 inOptions)
     {
         // Store the cached balances and token addresses in memory.


### PR DESCRIPTION
## Fixes
- Since we removed the Pausable inheritance from the Option.sol contract, we also need to remove the whenNotPaused modifier.