### PR TITLE
[M06] Misleading comments and docstrings

### DIFF
--- a/packages/primitive-contracts/contracts/option/extensions/Trader.sol
+++ b/packages/primitive-contracts/contracts/option/extensions/Trader.sol
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-
-
-
-
-
-
-
-
 pragma solidity ^0.6.2;
 
 /**
@@ -180,7 +172,7 @@ contract Trader is ITrader, ReentrancyGuard {
     /**
      * @dev Burn redeemTokens to withdraw underlyingTokens and strikeTokens from expired options.
      * @param optionToken The address of the option contract.
-     * @param unwindQuantity Quantity of redeemTokens to burn.
+     * @param unwindQuantity Quantity of option tokens used to calculate the amount of redeem tokens to burn.
      * @param receiver The underlyingTokens and redeemTokens are sent to the receiver address.
      */
     function safeUnwind(

--- a/packages/primitive-contracts/contracts/option/libraries/TraderLib.sol
+++ b/packages/primitive-contracts/contracts/option/libraries/TraderLib.sol
@@ -1,14 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-<<<<<<< HEAD
-=======
-
-
-
-
-
-
->>>>>>> hotfix/audit-fixes
 pragma solidity ^0.6.2;
 
 /**

--- a/packages/primitive-contracts/contracts/option/libraries/TraderLib.sol
+++ b/packages/primitive-contracts/contracts/option/libraries/TraderLib.sol
@@ -158,8 +158,8 @@ library TraderLib {
     /**
      * @dev Burn redeemTokens to withdraw underlyingTokens and strikeTokens from expired options.
      * @param optionToken The address of the option contract.
-     * @param unwindQuantity Quantity of redeemTokens to burn.
-     * @param receiver The underlyingTokens and redeemTokens are sent to the receiver address.
+     * @param unwindQuantity Quantity of option tokens used to calculate the amount of redeem tokens to burn.
+     * @param receiver The underlyingTokens are sent to the receiver address and the redeemTokens are burned.
      */
     function safeUnwind(
         IOption optionToken,


### PR DESCRIPTION
## Fixes
- Fixes comments and docstrings in Option.sol
- Fixes comments and docstrings in Trader.sol and TraderLib.sol

## Notes
- Comments should be completely overhauled and improved upon, with a focus on clarity.