### PR TITLE
[C03] Deposited funds can be stolen or lost due to transaction ordering

### DIFF
--- a/packages/primitive-contracts/contracts/option/primitives/Option.sol
+++ b/packages/primitive-contracts/contracts/option/primitives/Option.sol
@@ -4,6 +4,10 @@ pragma solidity ^0.6.2;
 
 /**
  * @title   Vanilla Option Token
+ * @notice  This is a low-level contract that is designed to be interacted with by
+ *          other sophisticated smart contracts which have important safety checks,
+ *          and not by externally owned accounts.
+ *          Use Primitive's Trader.sol contract to interact with this contract safely.
  * @author  Primitive
  */
 
@@ -90,7 +94,10 @@ contract Option is IOption, ERC20, ReentrancyGuard {
     }
 
     /**
-     * @dev Updates the cached balances to the actual current balances.
+     * @dev Updates the cached balances to match the actual current balances.
+     * Attempting to transfer tokens to this contract directly, in a separate transaction,
+     * is incorrect and could result in loss of funds. Calling this function will permanently lock any excess
+     * underlying or strike tokens which were erroneously sent to this contract.
      */
     function updateCacheBalances() external override nonReentrant {
         _updateCacheBalances(
@@ -114,8 +121,10 @@ contract Option is IOption, ERC20, ReentrancyGuard {
     /* === STATE MUTABLE === */
 
     /**
-     * @dev Mints optionTokens at a 1:1 ratio to underlyingToken deposits. Also mints Redeem tokens at a base:quote ratio.
-     * @notice inUnderlyings = outOptions. inUnderlying / strike ratio = outRedeems.
+     * @dev Warning: This low-level function should be called from a contract which performs important safety checks.
+     * This function should never be called directly by an externally owned account.
+     * Mints optionTokens at a 1:1 ratio to underlyingToken deposits. Also mints Redeem tokens at a base:quote ratio.
+     * @notice inUnderlyings = outOptionTokens. inUnderlying / strike ratio = outRedeemTokens.
      * @param receiver The newly minted tokens are sent to the receiver address.
      */
     function mintOptions(address receiver)
@@ -148,7 +157,9 @@ contract Option is IOption, ERC20, ReentrancyGuard {
     }
 
     /**
-     * @dev Sends out underlyingTokens then checks to make sure they are returned or paid for.
+     * @dev Warning: This low-level function should be called from a contract which performs important safety checks.
+     * This function should never be called directly by an externally owned account.
+     * Sends out underlyingTokens then checks to make sure they are returned or paid for.
      * @notice If the underlyingTokens are returned, only the fee has to be paid.
      * @param receiver The outUnderlyings are sent to the receiver address.
      * @param outUnderlyings Quantity of underlyingTokens to safeTransfer to receiver optimistically.
@@ -224,8 +235,10 @@ contract Option is IOption, ERC20, ReentrancyGuard {
     }
 
     /**
-     * @dev Burns redeemTokens to withdraw strikeTokens at a ratio of 1:1.
-     * @notice inRedeems = outStrikes. Only callable when strikeTokens are in the contract.
+     * @dev Warning: This low-level function should be called from a contract which performs important safety checks.
+     * This function should never be called directly by an externally owned account.
+     * Burns redeemTokens to withdraw strikeTokens at a ratio of 1:1.
+     * @notice inRedeemTokens = outStrikeTokens. Only callable when strikeTokens are in the contract.
      * @param receiver The inRedeems quantity of strikeTokens are sent to the receiver address.
      */
     function redeemStrikeTokens(address receiver)
@@ -256,10 +269,12 @@ contract Option is IOption, ERC20, ReentrancyGuard {
     }
 
     /**
-     * @dev If the option has expired, burn redeem tokens with withdraw underlying tokens.
+     * @dev Warning: This low-level function should be called from a contract which performs important safety checks.
+     * This function should never be called directly by an externally owned account.
+     * If the option has expired, burn redeem tokens to withdraw underlying tokens.
      * If the option is not expired, burn option and redeem tokens to withdraw underlying tokens.
-     * @notice inRedeems / strike ratio = outUnderlyings && inOptions >= outUnderlyings.
-     * @param receiver The outUnderlyings are sent to the receiver address.
+     * @notice inRedeemTokens / strike ratio = outUnderlyingTokens && inOptionTokens >= outUnderlyingTokens.
+     * @param receiver The outUnderlyingTokens are sent to the receiver address.
      */
     function closeOptions(address receiver)
         external

--- a/packages/primitive-contracts/contracts/option/primitives/Option.sol
+++ b/packages/primitive-contracts/contracts/option/primitives/Option.sol
@@ -7,6 +7,8 @@ pragma solidity ^0.6.2;
  * @notice  This is a low-level contract that is designed to be interacted with by
  *          other sophisticated smart contracts which have important safety checks,
  *          and not by externally owned accounts.
+ *          Incorrect usage through direct interaction from externally owned accounts
+ *          can lead to the loss of funds.
  *          Use Primitive's Trader.sol contract to interact with this contract safely.
  * @author  Primitive
  */


### PR DESCRIPTION
## Fixes
- Adds explicit comments at the beginning of each of the functions: `mintOptions`, `exerciseOptions`, `redeemStrikeTokens`, and `closeOptions` to explain how to safely interact with the Option.sol contract.
- Adds a `@notice` in the beginning of the Option.sol file to explain that only sophisticated smart contracts which make important safety checks should be the only entity calling the contract's functions. Externally owned accounts should never directly interact with the contract, and if they do it can lead to a loss of funds.

## Related Issues
#### - [H01] Fragile internal accounting mechanism may cause loss of funds

## Comments

The design of the Option.sol contract is inspired by the [`UniswapV2Pair`](https://github.com/Uniswap/uniswap-v2-core/blob/master/contracts/UniswapV2Pair.sol) contract.

The `UniswapV2Pair` contract separates logic into `core` and `periphery` contracts. The `periphery` contracts are sophisticated smart contracts which make important safety checks before calling into the `core` contracts as explained here:

![coreperipheryseparation](https://user-images.githubusercontent.com/38409137/89464384-39b2c380-d725-11ea-94a1-3200a92e31f2.png)


Similarly, Primitive's `Option.sol` contract is acting closely to the `core` and `Trader.sol` is acting closely to the `periphery`. 

Tokens must be sent to the Option.sol contract prior to the execution of the Option.sol contract's functions. This means that if tokens are transferred in separate transactions, it can lead to the loss of funds due to back-running, front-running, or calling `updateCacheBalances`. The Trader.sol contract is designed perform the two operations in a single atomic transaction:

1. Send tokens to Option.sol.
2. Call one of the core functions in Option.sol: `mintOptions`, `exerciseOptions`, `redeemStrikeTokens`, and `closeOptions`.

**Therefore, it is incorrect for an externally owned account (user) to be directly attempting to perform these operations, as it would not be in a single atomic transaction.**

Comments have been added to the Option.sol contract to reflect this.

In the private report for Primitive, it is stated: 

> In must be noted that users can still interact with the Option contract directly, as long as the necessary funds are deposited into it prior to the execution of the desired operation.

User's are not expected to interact directly with the Option.sol contract and should always use the Trader.sol contract (or other correctly implemented wrapper contracts) which makes the important safety checks.

If we opted to give the Trader.sol contract a special permission to interact with the Option.sol contract, so that externally owned accounts could not interact with it (protecting them), it could cause some issues. For example, other developers who wish to build their own wrappers around the Option.sol contract (with correct implementations) would also need to have their wrapper contracts permissioned to interact with the Option.sol contract. This clearly leads to some issues and questions around who makes these decisions or what contracts are accepted.

I also considered using [`isContract`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v3.1.0/contracts/utils/Address.sol#L26), but this could cause some weird interactions in the case that constructed code is calling the functions.

The Option.sol contract is designed in this way to allow the open development of correctly implemented wrapper contracts.

To reiterate:

**Features designed to support or protect traders are implemented with separate contracts that call into the Option.sol contract. Attempting to transfer tokens to the Option.sol contract directly, in a separate transaction, is incorrect and could result in loss of funds.**

## References

In the `UniswapV2Pair` contract, each of the core functions have explicit comments that they should only be called by contracts which perform the important safety checks:

https://github.com/Uniswap/uniswap-v2-core/blob/4dd59067c76dea4a0e8e4bfdda41877a6b16dedc/contracts/UniswapV2Pair.sol#L109

` // this low-level function should be called from a contract which performs important safety checks`