### PR TITLE
[H02] Flash loans of underlying tokens cannot be executed safely. [M07] Comments

### DIFF
--- a/packages/primitive-contracts/contracts/option/primitives/Option.sol
+++ b/packages/primitive-contracts/contracts/option/primitives/Option.sol
@@ -168,8 +168,8 @@ contract Option is IOption, ERC20, ReentrancyGuard {
      * are transferred into this contract prior to the function call. If an incorrect amount of tokens are transferred
      * into this contract, and this function is called, it can result in the loss of funds.
      * Sends out underlyingTokens then checks to make sure they are returned or paid for.
-     * This function enables flash exercises and flash loans. Only smart contracts who implements
-     * their own IFlash interface should be calling this function with the intention to initiate a flash exercise/loan.
+     * This function enables flash exercises and flash loans. Only smart contracts who implement
+     * their own IFlash interface should be calling this function to initiate a flash exercise/loan.
      * @notice If the underlyingTokens are returned, only the fee has to be paid.
      * @param receiver The outUnderlyings are sent to the receiver address.
      * @param outUnderlyings Quantity of underlyingTokens to safeTransfer to receiver optimistically.
@@ -210,7 +210,7 @@ contract Option is IOption, ERC20, ReentrancyGuard {
             address(this)
         );
 
-        // Calculate the Differences.
+        // Calculate the differences.
         inStrikes = strikeBalance.sub(_strikeCache);
         uint256 inUnderlyings = underlyingBalance.sub(
             _underlyingCache.sub(outUnderlyings)

--- a/packages/primitive-contracts/contracts/option/primitives/Option.sol
+++ b/packages/primitive-contracts/contracts/option/primitives/Option.sol
@@ -168,6 +168,8 @@ contract Option is IOption, ERC20, ReentrancyGuard {
      * are transferred into this contract prior to the function call. If an incorrect amount of tokens are transferred
      * into this contract, and this function is called, it can result in the loss of funds.
      * Sends out underlyingTokens then checks to make sure they are returned or paid for.
+     * This function enables flash exercises and flash loans. Only smart contracts who implements
+     * their own IFlash interface should be calling this function with the intention to initiate a flash exercise/loan.
      * @notice If the underlyingTokens are returned, only the fee has to be paid.
      * @param receiver The outUnderlyings are sent to the receiver address.
      * @param outUnderlyings Quantity of underlyingTokens to safeTransfer to receiver optimistically.
@@ -188,7 +190,7 @@ contract Option is IOption, ERC20, ReentrancyGuard {
         address underlyingToken = optionParameters.underlyingToken;
         (uint256 _underlyingCache, uint256 _strikeCache) = getCacheBalances();
 
-        // Require outUnderlyings > 0 and balane of underlings >= outUnderlyings.
+        // Require outUnderlyings > 0 and balance of underlyings >= outUnderlyings.
         require(outUnderlyings > 0, "ERR_ZERO");
         require(
             IERC20(underlyingToken).balanceOf(address(this)) >= outUnderlyings,


### PR DESCRIPTION
## Fixes
- Adds a comment above the `exerciseOptions` explaining that flash exercises and loans can only be initiated by other smart contracts who implement the IFlash.sol interface.

## Related Issues
#### - [M07] Convoluted implementation of exercise and flash loan features

## Comments

The `exerciseOptions` function takes these arguments:

```
function exerciseOptions(
        address receiver,
        uint256 outUnderlyings,
        bytes calldata data
    )
```

If data has a length greater than `0` it will trigger the flash exercise/loan callback function:
```
if (data.length > 0)
            IFlash(receiver).primitiveFlash(msg.sender, outUnderlyings, data);
```

Issue [H02] has the recommendation to add a function to Trader.sol to enable the safe execution of flash loans. 

> Consider implementing a secure method to perform flash loan operations in a single transaction, as it was done for the rest of the protocol’s operations in the Trader contract.

The private report also states:

> Alternatively, they [users] would need to code their own custom solutions to execute the entire operation in a single transaction, which could only be done by technically skilled users proficient in Solidity.

Flash exercises and loans should only be initiated by other smart contracts which implement the IFlash.sol interface. 

If we added a function to Trader.sol to initiate a flash exercise/loan, it would make the Trader.sol contract the `msg.sender` in the callback function. Therefore, the Trader.sol contract is the only smart contract in the context of the callback function `primitiveFlash`, which means all of the logic in `primitiveFlash` can only apply to the Trader.sol contract rather than the original caller.

## Comment on [M07]

While dual functionality is present in the function `exerciseOptions`, the purpose of the dual functionality is to enable **either** strike and options, or underlying tokens to be accepted as payment. 

Underlying tokens are sent out, and they must either be paid for with strike tokens + options equal to underlying tokens sent out, the original quantity underlying tokens, or a mixture of both. Correctly implemented wrapper contracts can take advantage of this ability to pay back a single loan in several different ways.

**`exerciseOptions` is a flash loan implicitly and separating this logic would be duplicating code.**
